### PR TITLE
feat: 전역/라우트 로딩·404 추가 및 블로그 notFound 연동

### DIFF
--- a/src/app/blog/[userId]/loading.tsx
+++ b/src/app/blog/[userId]/loading.tsx
@@ -1,0 +1,16 @@
+import ProfileSkeleton from "@/components/Skeletons/ProfileSkeleton";
+import PostCardSkeleton from "@/components/Skeletons/PostCardSkeleton";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-6 lg:px-40">
+      <ProfileSkeleton />
+      <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <PostCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/blog/[userId]/not-found.tsx
+++ b/src/app/blog/[userId]/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <section className="w-full px-6 py-16 flex flex-col items-center text-center">
+      <h1 className="text-2xl font-semibold text-gray-900">블로그를 찾을 수 없어요</h1>
+      <p className="mt-2 text-gray-600">사용자가 존재하지 않거나 공개 범위가 아닙니다.</p>
+      <div className="mt-6 flex gap-3">
+        <Link href="/" className="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">홈으로</Link>
+        <Link href="/" className="px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50">게시글 탐색</Link>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/blog/[userId]/page.tsx
+++ b/src/app/blog/[userId]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import BlogPageClient from '@/app/blog/[userId]/BlogPageClient';
 import { getUserProfile } from '@/apis/userApi';
 import { truncate, toAbsoluteUrl } from '@/utils/seo';
+import { notFound } from 'next/navigation';
 
 export async function generateMetadata(
   { params }: { params: Promise<{ userId: string }> }
@@ -38,6 +39,12 @@ export async function generateMetadata(
   }
 }
 
-export default function BlogPage() {
+export default async function BlogPage({ params }: { params: Promise<{ userId: string }> }) {
+  const { userId } = await params;
+  try {
+    await getUserProfile(userId);
+  } catch {
+    return notFound();
+  }
   return <BlogPageClient />;
 }

--- a/src/app/chatbot/[userId]/loading.tsx
+++ b/src/app/chatbot/[userId]/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <div className="w-full p-6 lg:px-40">
+      <div className="h-6 w-36 bg-gray-200 rounded animate-pulse" />
+      <div className="mt-4 space-y-2">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className={`h-12 bg-gray-200 rounded animate-pulse ${i % 2 ? 'ml-12' : 'mr-12'}`} />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Spinner from "@/components/Common/Spinner";
+
+export default function GlobalLoading() {
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setShow(true), 300); // avoid flash on quick transitions
+    return () => clearTimeout(t);
+  }, []);
+  if (!show) return null;
+  return (
+    <div className="fixed inset-0 z-50 bg-black/10 backdrop-blur-[1px] flex items-center justify-center">
+      <div className="flex items-center gap-3 px-4 py-3 rounded-md bg-white shadow">
+        <Spinner size={20} />
+        <span className="text-sm text-gray-700">로딩 중…</span>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <section className="w-full px-6 py-16 flex flex-col items-center text-center">
+      <h1 className="text-2xl font-semibold text-gray-900">페이지를 찾을 수 없어요</h1>
+      <p className="mt-2 text-gray-600">요청하신 주소가 변경되었거나 존재하지 않습니다.</p>
+      <div className="mt-6 flex gap-3">
+        <Link href="/" className="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">홈으로</Link>
+        <Link href="/write" className="px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50">글 쓰러 가기</Link>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/post/[postId]/loading.tsx
+++ b/src/app/post/[postId]/loading.tsx
@@ -1,0 +1,6 @@
+import PostDetailSkeleton from "@/components/Skeletons/PostDetailSkeleton";
+
+export default function Loading() {
+  return <PostDetailSkeleton />;
+}
+

--- a/src/app/post/[postId]/not-found.tsx
+++ b/src/app/post/[postId]/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <section className="w-full px-6 py-16 flex flex-col items-center text-center">
+      <h1 className="text-2xl font-semibold text-gray-900">게시글을 찾을 수 없어요</h1>
+      <p className="mt-2 text-gray-600">삭제되었거나 주소가 잘못되었을 수 있습니다.</p>
+      <div className="mt-6 flex gap-3">
+        <Link href="/" className="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">홈으로</Link>
+        <Link href="/" className="px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50">다른 글 보러가기</Link>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/write/loading.tsx
+++ b/src/app/write/loading.tsx
@@ -1,0 +1,15 @@
+import PostCardSkeleton from "@/components/Skeletons/PostCardSkeleton";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-6 lg:px-40">
+      <div className="h-8 w-40 bg-gray-200 rounded animate-pulse" />
+      <div className="mt-4 space-y-3">
+        <div className="h-10 bg-gray-200 rounded animate-pulse" />
+        <div className="h-10 bg-gray-200 rounded animate-pulse" />
+        <div className="h-64 bg-gray-200 rounded animate-pulse" />
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Common/Spinner.tsx
+++ b/src/components/Common/Spinner.tsx
@@ -1,0 +1,12 @@
+export default function Spinner({ size = 24 }: { size?: number }) {
+  const px = `${size}px`;
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className="inline-block animate-spin rounded-full border-2 border-gray-300 border-t-blue-500"
+      style={{ width: px, height: px }}
+    />
+  );
+}
+

--- a/src/components/Skeletons/PostCardSkeleton.tsx
+++ b/src/components/Skeletons/PostCardSkeleton.tsx
@@ -1,0 +1,13 @@
+export default function PostCardSkeleton() {
+  return (
+    <div className="rounded-lg border border-gray-200 overflow-hidden bg-white">
+      <div className="h-40 w-full bg-gray-200 animate-pulse" />
+      <div className="p-4 space-y-3">
+        <div className="h-5 bg-gray-200 rounded animate-pulse w-3/4" />
+        <div className="h-4 bg-gray-200 rounded animate-pulse w-5/6" />
+        <div className="h-4 bg-gray-200 rounded animate-pulse w-2/3" />
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Skeletons/PostDetailSkeleton.tsx
+++ b/src/components/Skeletons/PostDetailSkeleton.tsx
@@ -1,0 +1,16 @@
+export default function PostDetailSkeleton() {
+  return (
+    <article className="w-full p-8 lg:px-40 bg-white">
+      <div className="space-y-4">
+        <div className="h-8 w-2/3 bg-gray-200 rounded animate-pulse" />
+        <div className="h-5 w-1/3 bg-gray-200 rounded animate-pulse" />
+      </div>
+      <div className="mt-6 space-y-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="h-4 bg-gray-200 rounded animate-pulse w-full" />
+        ))}
+      </div>
+    </article>
+  );
+}
+

--- a/src/components/Skeletons/ProfileSkeleton.tsx
+++ b/src/components/Skeletons/ProfileSkeleton.tsx
@@ -1,0 +1,14 @@
+export default function ProfileSkeleton() {
+  return (
+    <div className="w-full max-w-5xl mx-auto p-6">
+      <div className="flex items-center gap-4">
+        <div className="w-16 h-16 rounded-full bg-gray-200 animate-pulse" />
+        <div className="space-y-2 flex-1">
+          <div className="h-5 w-40 bg-gray-200 rounded animate-pulse" />
+          <div className="h-4 w-64 bg-gray-200 rounded animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
  - 전역 로딩 오버레이(src/app/loading.tsx), 전역 404(src/app/not-found.tsx)
  - 라우트 로딩/404: post, blog, write, chatbot
  - 공용 컴포넌트: Spinner, PostCardSkeleton, PostDetailSkeleton, ProfileSkeleton
  - 블로그 페이지: getUserProfile 실패 시 notFound() 처리

<!--
제목 가이드(권장): [type(scope)] subject
예) [feat(ai)] add RAG filter for post_id
-->

## 요약
- 작업 목적과 배경을 3~5줄로 간단히 설명하세요.

## 관련 이슈
- closes #
- relates #

## Context
- 현재 동작/제약, 대안 검토, 관련 문서/링크 등

## Changes
- 변경 사항을 항목별로 나열하세요.

## Breaking Changes
- 호환성 이슈가 있다면 명시하고 마이그레이션 방법을 적으세요.

## Test Plan
- [명령] 로컬/CI에서 실행한 명령: `...`
- [시나리오] 재현 및 확인 단계: 1) … 2) … 3) …
- 기대 결과와 실제 결과를 적고, 가능한 경우 스크린샷/로그를 첨부하세요.

## 스크린샷/증빙(선택)
- 기능 화면, 로그, API 응답 등

<img width="2920" height="1440" alt="image" src="https://github.com/user-attachments/assets/d14b7cac-aca9-435b-9a6e-d72c9505c7d9" />

<img width="2920" height="1440" alt="image" src="https://github.com/user-attachments/assets/61404bd2-adbc-40e3-bf12-80e3986c3aba" />


## 체크리스트
- [ ] 셀프 리뷰 완료(중복/불필요 파일 제거)
- [ ] Lint/빌드 통과
- [ ] 테스트 코드/케이스 추가 또는 N/A 사유 명시
- [ ] 문서/README/ENV 예시 업데이트
- [ ] 필요한 라벨 부착(예: `ai-review`, `ai-pr-suggest`)

<!--
주의
- PR 봇 코멘트는 인라인 라인 코멘트가 아닌 일반 코멘트로 남습니다. # 현재 비 활성화
- 노션 보고서는 병합 시 자동 생성되며, 기본 State는 "새로 생성"으로 기록됩니다.
- Area는 현재 템플릿 선택만 반영됩니다. 필요 시 라벨→Area 자동 매핑을 요청하세요.
-->