### PR TITLE
feat: 페이지 네이션 공용 컴포넌트 도입 + 반응형 축약 페이지 적용

### DIFF
--- a/.github/workflows/notion-report.yml
+++ b/.github/workflows/notion-report.yml
@@ -46,7 +46,7 @@ jobs:
           # Area 기본값: AI
           # - 필요 시 'Frontend' 또는 'Spring'으로 변경하세요.
           # - 라벨 기반 자동 설정으로 바꾸려면 이후에 AREA 계산 로직을 추가하면 됩니다.
-          AREA="AI"
+          AREA="Frontend"
 
           curl -sS -X POST "https://api.notion.com/v1/pages" \
             -H "Authorization: Bearer ${NOTION_TOKEN}" \

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -6,6 +6,7 @@ import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { PostList } from '@/components/Post/PostList';
 import { BlogControls } from '@/components/Blog/BlogControls';
 import { Bars3BottomLeftIcon } from '@heroicons/react/24/outline';
+import Pagination from '@/components/Common/Pagination';
 
 type ViewMode = 'card' | 'list';
 
@@ -62,40 +63,11 @@ export default function HomeClient() {
         <PostList posts={posts} viewMode={viewMode} />
       </main>
 
-      {/* 페이지네이션: 페이지가 2개 이상일 때만 표시 */}
-      {totalPages > 1 && (
-        <nav className="py-4 flex justify-center space-x-2">
-          {!first && (
-            <button
-              onClick={() => handlePageChange(number - 1)}
-              className="px-3 py-1 border rounded"
-            >
-              이전
-            </button>
-          )}
-
-          {Array.from({ length: totalPages }, (_, idx) => (
-            <button
-              key={idx}
-              onClick={() => handlePageChange(idx)}
-              className={`px-3 py-1 border rounded ${
-                idx === number ? 'font-bold underline text-blue-600' : ''
-              }`}
-            >
-              {idx + 1}
-            </button>
-          ))}
-
-          {!last && (
-            <button
-              onClick={() => handlePageChange(number + 1)}
-              className="px-3 py-1 border rounded"
-            >
-              다음
-            </button>
-          )}
-        </nav>
-      )}
+      <Pagination
+        page={number}
+        totalPages={totalPages}
+        onChange={handlePageChange}
+      />
     </div>
   );
 }

--- a/src/app/blog/[userId]/BlogPageClient.tsx
+++ b/src/app/blog/[userId]/BlogPageClient.tsx
@@ -18,6 +18,7 @@ import { DeleteModal } from '@/components/Blog/DeleteModal';
 import { DraggableModal } from '@/components/Common/DraggableModal'
 import { ChatWindow } from '@/components/Chat/ChatWindow'
 import { ChatViewButton } from '@/components/Chat/ChatViewButton'
+import Pagination from '@/components/Common/Pagination'
 
 type ViewMode = 'card' | 'list';
 
@@ -142,6 +143,7 @@ export default function BlogPageClient() {
   if (loadingUser) return <p>프로필 로딩 중…</p>;
   if (errorUser)  return <p className="text-red-500">{errorUser}</p>;
 
+
   return (
     <div className='w-full'>
       <main className="flex-1 w-full px-5 md:px-16 py-8">
@@ -176,37 +178,12 @@ export default function BlogPageClient() {
           <>
             <PostsGrid posts={posts} viewMode={viewMode} />
 
-            {/* 페이지네이션: 페이지가 2개 이상일 때만 표시 */}
-            {pageData && pageData.totalPages > 1 && (
-              <nav className="py-4 flex justify-center space-x-2">
-                {page > 0 && (
-                  <button
-                    onClick={() => handlePageChange(page - 1)}
-                    className="px-3 py-1 border rounded"
-                  >
-                    이전
-                  </button>
-                )}
-                {Array.from({ length: pageData.totalPages }, (_, idx) => (
-                  <button
-                    key={idx}
-                    onClick={() => handlePageChange(idx)}
-                    className={`px-3 py-1 border rounded ${
-                      idx === page ? 'font-bold underline text-blue-600' : ''
-                    }`}
-                  >
-                    {idx + 1}
-                  </button>
-                ))}
-                {!pageData.last && (
-                  <button
-                    onClick={() => handlePageChange(page + 1)}
-                    className="px-3 py-1 border rounded"
-                  >
-                    다음
-                  </button>
-                )}
-              </nav>
+            {pageData && (
+              <Pagination
+                page={page}
+                totalPages={pageData.totalPages}
+                onChange={handlePageChange}
+              />
             )}
           </>
         )}

--- a/src/components/Common/Pagination.tsx
+++ b/src/components/Common/Pagination.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React from 'react';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+export interface PaginationProps {
+  page: number; // 0-based
+  totalPages: number;
+  onChange: (page: number) => void;
+  className?: string;
+  showWhenSingle?: boolean; // default: false
+  prevLabel?: string; // default: '이전'
+  nextLabel?: string; // default: '다음'
+  rangeDesktop?: number; // default: 2
+  rangeMobile?: number; // default: 1
+}
+
+function buildPageItems(current: number, total: number, range: number) {
+  const items: (number | 'ellipsis')[] = [];
+  const allThreshold = 2 * range + 5; // first/last + range*2 around current
+  if (!total || total <= allThreshold) {
+    return Array.from({ length: total }, (_, i) => i);
+  }
+
+  const firstIdx = 0;
+  const lastIdx = total - 1;
+  const set = new Set<number>([firstIdx, lastIdx]);
+
+  for (let i = current - range; i <= current + range; i++) {
+    if (i >= firstIdx && i <= lastIdx) set.add(i);
+  }
+
+  if (current <= range) {
+    for (let i = 1; i <= range; i++) set.add(i);
+  }
+  if (current >= lastIdx - range) {
+    for (let i = 1; i <= range; i++) set.add(lastIdx - i);
+  }
+
+  const pages = Array.from(set).sort((a, b) => a - b);
+  for (let i = 0; i < pages.length; i++) {
+    const prev = pages[i - 1];
+    const curr = pages[i];
+    if (i > 0 && curr - prev > 1) items.push('ellipsis');
+    items.push(curr);
+  }
+  return items;
+}
+
+export function Pagination({
+  page,
+  totalPages,
+  onChange,
+  className = '',
+  showWhenSingle = false,
+  prevLabel = '이전',
+  nextLabel = '다음',
+  rangeDesktop = 2,
+  rangeMobile = 1,
+}: PaginationProps) {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const range = isMobile ? rangeMobile : rangeDesktop;
+
+  if (!showWhenSingle && totalPages <= 1) return null;
+
+  const items = buildPageItems(page, totalPages, range);
+  const isFirst = page <= 0;
+  const isLast = page >= totalPages - 1;
+
+  return (
+    <nav className={`py-4 flex justify-center space-x-2 ${className}`} aria-label="Pagination">
+      {!isFirst && (
+        <button
+          type="button"
+          onClick={() => onChange(page - 1)}
+          className="px-3 py-1 border rounded"
+          aria-label="Previous page"
+        >
+          {prevLabel}
+        </button>
+      )}
+
+      {items.map((item, idx) =>
+        item === 'ellipsis' ? (
+          <span key={`e-${idx}`} className="px-3 py-1 text-gray-400 select-none">…</span>
+        ) : (
+          <button
+            key={item}
+            type="button"
+            onClick={() => onChange(item)}
+            aria-current={item === page ? 'page' : undefined}
+            className={`px-3 py-1 border rounded ${
+              item === page ? 'font-bold underline text-blue-600' : ''
+            }`}
+          >
+            {item + 1}
+          </button>
+        )
+      )}
+
+      {!isLast && (
+        <button
+          type="button"
+          onClick={() => onChange(page + 1)}
+          className="px-3 py-1 border rounded"
+          aria-label="Next page"
+        >
+          {nextLabel}
+        </button>
+      )}
+    </nav>
+  );
+}
+
+export default Pagination;
+


### PR DESCRIPTION
feat: 페이지 네이션 공용 컴포넌트 도입 + 반응형 축약 페이지 적용

  - src/components/Common/Pagination.tsx 추가 (재사용 가능한 페이지네이션)
  - 데스크탑 ±2 / 모바일 ±1 범위로 숫자 축약, 첫/끝 고정, 중간 … 표시
  - totalPages <= 1이면 nav 미노출, 이전/다음은 유효할 때만 표시
  - HomeClient, BlogPageClient에 컴포넌트 적용하여 중복 제거 및 일관성 확보