### PR TITLE
feat: 챗봇 게시글 범위 질의(post_id) 지원 + 챗봇 UI 개선 && feat: 페이지 네이션 공용 컴포넌트 도입 + 반응형 축약 페이지 적용

### DIFF
--- a/.github/workflows/notion-report.yml
+++ b/.github/workflows/notion-report.yml
@@ -46,7 +46,7 @@ jobs:
           # Area 기본값: AI
           # - 필요 시 'Frontend' 또는 'Spring'으로 변경하세요.
           # - 라벨 기반 자동 설정으로 바꾸려면 이후에 AREA 계산 로직을 추가하면 됩니다.
-          AREA="AI"
+          AREA="Frontend"
 
           curl -sS -X POST "https://api.notion.com/v1/pages" \
             -H "Authorization: Bearer ${NOTION_TOKEN}" \

--- a/TASK.md
+++ b/TASK.md
@@ -1,35 +1,65 @@
-# NEXT.js 메타데이터 주입 작업 계획
+## [feat(ai/chat)] 포스트 상세에서 "이 글에 대해 질문하기" 전환 계획
 
-## 목표
-- 페이지 SSR 단계에서 `generateMetadata`로 동적 메타데이터를 주입하고, 레이아웃에 Static Metadata를 정의하여 SEO/공유 미리보기 품질을 개선한다.
+### 목표
+- 포스트 상세 화면에서 챗봇이 블로그 전체가 아닌 해당 "게시글 범위"로 질의하도록 전환.
+- AI API 요청 바디에 `post_id`를 전달하고, SSE 신규 이벤트(`exist_in_post_status`)를 처리.
+- 모바일/데스크탑 모두에서 "이 글에 대한 질문"임이 UI로 명확히 드러나도록 표시.
 
-## 대상 및 범위
-- 홈: `src/app/page.tsx`
-- 블로그: `src/app/blog/[userId]/page.tsx`
-- 포스트: `src/app/post/[postId]/page.tsx`
-- 레이아웃: `src/app/layout.tsx`
+### 변경 범위 (Scope)
+- API 클라이언트: `src/apis/aiApi.ts` — `askChatAPI`에 `postId?: number` 추가, 요청 바디에 `post_id` 포함, `exist_in_post_status` 콜백 처리 추가.
+- 포스트 상세:
+  - `src/components/Chat/ChatViewButton.tsx` — 버튼 문구를 "이 글에 대해 질문하기"로 변경, 모바일 링크에 `?postId=...` 쿼리 추가.
+  - `src/app/post/[postId]/PostDetailClient.tsx` — `<ChatWindow>`에 `postId` 전달.
+- 챗봇 UI:
+  - `src/components/Chat/ChatWindow.tsx` — `postId` prop(선택) 지원, `askChatAPI` 호출 시 전달. `postId`가 있으면 카테고리 필터 비활성화/숨김 및 상단 배지로 "이 글 범위로 질문 중" 표시.
+  - `src/app/chatbot/[userId]/page.tsx` — `searchParams`의 `postId` 수신, 전역 챗봇 화면에서도 글 범위 배지/가이드 노출, 카테고리 비활성화. 초기 안내 문구를 "이 글에 대해 물어보세요"(postId 있을 때)로 분기.
+  - `src/components/Chat/ContextViewer.tsx` 등 기존 컴포넌트는 로직 변경 없이 재사용.
 
-## 작업 항목
-1) CSR/SSR 분리
-- 홈 페이지의 기존 CSR 로직을 `src/app/HomeClient.tsx`로 분리하고, `src/app/page.tsx`는 서버 컴포넌트로 전환.
-- 블로그 페이지의 기존 CSR 로직을 `src/app/blog/[userId]/BlogPageClient.tsx`로 분리하고, `src/app/blog/[userId]/page.tsx`는 서버 컴포넌트로 전환.
-- 포스트 페이지는 현재 CSR/SSR 분리(본문 SSR)가 되어 있으므로 구조 유지.
+### API 반영 사항
+- 엔드포인트: `POST /ai/ask` (인증 필요)
+- 요청 바디에 `post_id`(number, optional) 추가. 존재 시 `category_id`는 서버에서 무시됨.
+- SSE 이벤트 추가 처리: `exist_in_post_status` → `boolean` 값을 콜백으로 노출하여 UI 배지 상태 업데이트 가능하도록 함.
 
-2) 페이지별 generateMetadata 구현
-- 홈(`page.tsx`): 서비스 기본 메타(title/description/openGraph/twitter) 반환.
-- 블로그(`blog/[userId]/page.tsx`): `getUserProfile(userId)`로 사용자 정보를 조회해 title/description/이미지 동적 구성.
-- 포스트(`post/[postId]/page.tsx`): `getBlogById(postId)`로 글 정보를 조회해 title/description/썸네일 기반 메타 구성.
-- 모든 페이지는 실패 시 안전한 기본 메타로 폴백.
+### 구현 단계
+1) API 클라이언트 보강
+   - `askChatAPI(question, userId, categoryId, personaId, onContext, onAnswerChunk, options?)` 시그니처를 확장:
+     - `options?: { postId?: number; onExistInPostStatus?: (exists: boolean) => void }`
+     - 요청 바디에 `post_id: options?.postId` 포함
+     - SSE 파서에서 `event: exist_in_post_status` 수신 시 `onExistInPostStatus?.(true|false)` 호출
 
-3) 레이아웃 Static Metadata 강화
-- `src/app/layout.tsx`의 `metadata`를 `title.template`/`title.default`/`openGraph`/`twitter`/`icons` 등으로 확장.
-- 기본 OG/Twitter 이미지(`/logo.jpeg`) 설정 및 사이트 기본 설명 통일.
+2) 포스트 상세 → 챗봇 연결
+   - `ChatViewButton` 문구 변경 및 모바일 링크를 `/chatbot/${userId}?postId=${postId}`로 생성
+   - `PostDetailClient`에서 `<ChatWindow userId={post.userId} postId={post.id} />`로 전달
 
-## 수용 기준
-- 각 대상 페이지에서 메타태그가 의도한 값으로 서버 사이드 주입됨(OG/Twitter 포함).
-- CSR 상호작용 및 페이지 기능은 기존과 동일하게 동작.
-- 빌드/런/린트 정상.
+3) 챗봇 UI 업데이트
+   - `ChatWindow`에 `postId?: number` prop 추가
+   - `postId`가 존재하면:
+     - 상단에 배지/알림: "이 글 범위로 질문 중"(필요 시 제목 일부 표기)
+     - 카테고리 선택 버튼 숨김 또는 비활성화 + 툴팁/설명 추가("게시글 범위 질문에서는 카테고리 필터가 적용되지 않습니다")
+     - `askChatAPI` 호출 시 `options.postId` 전달, `onExistInPostStatus`로 존재 여부에 따라 배지 색상/텍스트 업데이트
 
-## 변경 파일
-- 추가: `src/app/HomeClient.tsx`, `src/app/blog/[userId]/BlogPageClient.tsx`
-- 수정: `src/app/page.tsx`, `src/app/blog/[userId]/page.tsx`, `src/app/post/[postId]/page.tsx`, `src/app/layout.tsx`
+4) 전역 챗봇 라우트 지원
+   - `src/app/chatbot/[userId]/page.tsx`에서 `searchParams.postId` 파싱 → `number | undefined`
+   - 위와 동일한 UI 분기와 바디 파라미터 전달 적용
+
+5) 카피/가이드 문구 정리
+   - 버튼: "이 글에 대해 질문하기"
+   - 전역 챗봇 첫 안내: postId 존재 시 "이 글에 대해 물어보세요" / 없으면 기존 "블로그에 대해 물어보세요"
+
+### 변경 파일(예정)
+- `src/apis/aiApi.ts`
+- `src/components/Chat/ChatWindow.tsx`
+- `src/app/chatbot/[userId]/page.tsx`
+- `src/app/post/[postId]/PostDetailClient.tsx`
+- `src/components/Chat/ChatViewButton.tsx`
+
+### 검증 계획
+- 포스트 상세(데스크탑): 모달 챗봇 열기 → 상단 배지 노출, 카테고리 버튼 비활성화, 질문 전송 시 서버로 `post_id` 포함 확인(네트워크 탭) 및 답변 수신.
+- 포스트 상세(모바일): 링크로 챗봇 페이지 이동(`/chatbot/:userId?postId=...`) → 동일 UI/동작.
+- 전역 챗봇(블로그 범위): `postId` 없는 일반 진입 시 기존과 동일 동작 유지.
+- SSE: `context`, `answer`, `end`, `exist_in_post_status` 정상 파싱 및 UI 반영 확인.
+
+### 고려/주의 사항
+- `postId` 모드에서 카테고리 필터는 서버에서 무시되므로 UI에서 혼동 방지(숨기거나 disabled 처리).
+- 인증 만료 흐름은 `aiFetch` 재시도로 유지. 401 시 기존 로직 준수.
+- 타입 호환성: 선택적 매개변수 추가로 역호환 보장.

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -6,6 +6,7 @@ import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { PostList } from '@/components/Post/PostList';
 import { BlogControls } from '@/components/Blog/BlogControls';
 import { Bars3BottomLeftIcon } from '@heroicons/react/24/outline';
+import Pagination from '@/components/Common/Pagination';
 
 type ViewMode = 'card' | 'list';
 
@@ -62,40 +63,11 @@ export default function HomeClient() {
         <PostList posts={posts} viewMode={viewMode} />
       </main>
 
-      {/* 페이지네이션: 페이지가 2개 이상일 때만 표시 */}
-      {totalPages > 1 && (
-        <nav className="py-4 flex justify-center space-x-2">
-          {!first && (
-            <button
-              onClick={() => handlePageChange(number - 1)}
-              className="px-3 py-1 border rounded"
-            >
-              이전
-            </button>
-          )}
-
-          {Array.from({ length: totalPages }, (_, idx) => (
-            <button
-              key={idx}
-              onClick={() => handlePageChange(idx)}
-              className={`px-3 py-1 border rounded ${
-                idx === number ? 'font-bold underline text-blue-600' : ''
-              }`}
-            >
-              {idx + 1}
-            </button>
-          ))}
-
-          {!last && (
-            <button
-              onClick={() => handlePageChange(number + 1)}
-              className="px-3 py-1 border rounded"
-            >
-              다음
-            </button>
-          )}
-        </nav>
-      )}
+      <Pagination
+        page={number}
+        totalPages={totalPages}
+        onChange={handlePageChange}
+      />
     </div>
   );
 }

--- a/src/app/blog/[userId]/BlogPageClient.tsx
+++ b/src/app/blog/[userId]/BlogPageClient.tsx
@@ -167,7 +167,15 @@ export default function BlogPageClient() {
             selectedCategory={selectedCategory}
             onOpen={() => setIsCatModalOpen(true)}
           />
-          {isMyBlog && <BlogControls userId={paramUserId} sort={sort} setSort={setSort} viewMode={viewMode} setViewMode={setViewMode} isViewModeToggleDisabled={isMobile} />}
+          <BlogControls
+            userId={paramUserId}
+            sort={sort}
+            setSort={setSort}
+            viewMode={viewMode}
+            setViewMode={setViewMode}
+            isViewModeToggleDisabled={isMobile}
+            showUserControls={isMyBlog}
+          />
         </div>
 
         {loadingPosts ? (

--- a/src/app/blog/[userId]/BlogPageClient.tsx
+++ b/src/app/blog/[userId]/BlogPageClient.tsx
@@ -18,6 +18,7 @@ import { DeleteModal } from '@/components/Blog/DeleteModal';
 import { DraggableModal } from '@/components/Common/DraggableModal'
 import { ChatWindow } from '@/components/Chat/ChatWindow'
 import { ChatViewButton } from '@/components/Chat/ChatViewButton'
+import Pagination from '@/components/Common/Pagination'
 
 type ViewMode = 'card' | 'list';
 
@@ -142,6 +143,7 @@ export default function BlogPageClient() {
   if (loadingUser) return <p>프로필 로딩 중…</p>;
   if (errorUser)  return <p className="text-red-500">{errorUser}</p>;
 
+
   return (
     <div className='w-full'>
       <main className="flex-1 w-full px-5 md:px-16 py-8">
@@ -176,37 +178,12 @@ export default function BlogPageClient() {
           <>
             <PostsGrid posts={posts} viewMode={viewMode} />
 
-            {/* 페이지네이션: 페이지가 2개 이상일 때만 표시 */}
-            {pageData && pageData.totalPages > 1 && (
-              <nav className="py-4 flex justify-center space-x-2">
-                {page > 0 && (
-                  <button
-                    onClick={() => handlePageChange(page - 1)}
-                    className="px-3 py-1 border rounded"
-                  >
-                    이전
-                  </button>
-                )}
-                {Array.from({ length: pageData.totalPages }, (_, idx) => (
-                  <button
-                    key={idx}
-                    onClick={() => handlePageChange(idx)}
-                    className={`px-3 py-1 border rounded ${
-                      idx === page ? 'font-bold underline text-blue-600' : ''
-                    }`}
-                  >
-                    {idx + 1}
-                  </button>
-                ))}
-                {!pageData.last && (
-                  <button
-                    onClick={() => handlePageChange(page + 1)}
-                    className="px-3 py-1 border rounded"
-                  >
-                    다음
-                  </button>
-                )}
-              </nav>
+            {pageData && (
+              <Pagination
+                page={page}
+                totalPages={pageData.totalPages}
+                onChange={handlePageChange}
+              />
             )}
           </>
         )}

--- a/src/app/blog/[userId]/BlogPageClient.tsx
+++ b/src/app/blog/[userId]/BlogPageClient.tsx
@@ -151,7 +151,7 @@ export default function BlogPageClient() {
         <div className='flex flex-col lg:flex-row gap-4 items-center justify-between'>
           <div className='flex flex-row gap-4 items-center justify-between'>
             {profile && <UserProfileHeader profile={profile} isMyBlog={isMyBlog} />}
-            <ChatViewButton userId={paramUserId} onClick={() => setShowChat(true)}/>
+            <ChatViewButton userId={paramUserId} variant="blog" onClick={() => setShowChat(true)}/>
           </div>
           {showChat && (
             <DraggableModal

--- a/src/app/chatbot/[userId]/page.tsx
+++ b/src/app/chatbot/[userId]/page.tsx
@@ -136,7 +136,7 @@ export default function ChatPage() {
   return (
     <div className='bg-[rgb(244,246,248)] w-full h-full'>
       <div className="px-6 md:px-16 w-full flex flex-col items-center">
-        <div className='flex gap-2 w-full justify-between sticky top-0 z-10 pb-4 bg-[rgb(244,246,248)] flex-wrap max-w-5xl'>
+        <div className='flex gap-2 w-full justify-between sticky top-0 z-10 py-8 bg-[rgb(244,246,248)] flex-wrap max-w-5xl'>
           <ProfileHeader profile={profile} />
           {postId != null && (
             <div className='my-auto'>
@@ -147,7 +147,7 @@ export default function ChatPage() {
           )}
         </div>
       
-        <div className="flex flex-col items-center justify-center pt-6 w-full max-w-5xl">
+        <div className="flex flex-col items-center justify-center w-full max-w-5xl">
           {postId == null && (
             <CategorySelector
               userId={userId!}
@@ -176,9 +176,9 @@ export default function ChatPage() {
           {messages.length === 0 && (
             <div className="flex justify-center items-center h-[25vh]">
               {postId != null ? (
-                <span className="text-4xl text-gray-800 text-center">이 글에 대해 물어보세요</span>
+                <span className="text-2xl md:text-4xl text-gray-800 text-center">이 글에 대해 물어보세요</span>
               ) : (
-                <span className="text-4xl text-gray-800 text-center">블로그에 대해 물어보세요</span>
+                <span className="text-2xl md:text-4xl text-gray-800 text-center">블로그에 대해 물어보세요</span>
               )}
             </div>
           )}

--- a/src/app/post/[postId]/PostDetailClient.tsx
+++ b/src/app/post/[postId]/PostDetailClient.tsx
@@ -63,7 +63,7 @@ export default function PostDetailClient({ postId }: { postId: string }) {
     <>
       {isMyPost && <PostDetailActions postId={post.id} />}
       <PostDetailHeader post={post}>
-        <ChatViewButton userId={post.userId} onClick={() => setShowChat(true)} />
+        <ChatViewButton userId={post.userId} postId={post.id} onClick={() => setShowChat(true)} />
       </PostDetailHeader>
 
       <PostNavbar post={post} liked={liked} onLike={handleLike} />
@@ -71,8 +71,8 @@ export default function PostDetailClient({ postId }: { postId: string }) {
       {/* 본문은 SSR로, 여기서는 렌더하지 않음 */}
 
       {showChat && (
-        <DraggableModal path={`/chatbot/${post.userId}`} onClose={() => setShowChat(false)}>
-          <ChatWindow userId={post.userId} />
+        <DraggableModal path={`/chatbot/${post.userId}?postId=${post.id}`} onClose={() => setShowChat(false)}>
+          <ChatWindow userId={post.userId} postId={post.id} postTitle={post.title} />
         </DraggableModal>
       )}
     </>

--- a/src/app/write/WritePostClient.tsx
+++ b/src/app/write/WritePostClient.tsx
@@ -94,7 +94,7 @@ export default function WritePostClient({ postId, initialData }: Props) {
   };
 
   return (
-    <div className="w-full max-w-4xl mx-auto p-4 md:p-8">
+    <div className="w-full p-4 md:pt-8 md:px-16">
       <div className="space-y-8 mb-8">
         <div>
           <input

--- a/src/components/Blog/BlogControls.tsx
+++ b/src/components/Blog/BlogControls.tsx
@@ -28,7 +28,7 @@ export function BlogControls({
   isViewModeToggleDisabled = false
 }: Props) {
   return (
-    <div className="flex flex-col sm:flex-row gap-4 justify-between items-center w-full">
+    <div className="flex flex-col sm:flex-row gap-4 justify-between items-center">
       {/* 좌측: 글쓰기, 설정 버튼 (선택적 렌더링) */}
       {showUserControls ? (
         <div className="flex gap-4">

--- a/src/components/Chat/ChatViewButton.tsx
+++ b/src/components/Chat/ChatViewButton.tsx
@@ -7,9 +7,11 @@ import { Button } from '@/components/Common/Button'
 interface Props {
   userId: string
   onClick: () => void
+  postId?: number | string
+  variant?: 'post' | 'blog'
 }
 
-export function ChatViewButton({ userId, onClick }: Props) {
+export function ChatViewButton({ userId, onClick, postId, variant = 'post' }: Props) {
   const [isMobile, setIsMobile] = useState(false)
 
   useEffect(() => {
@@ -35,7 +37,7 @@ export function ChatViewButton({ userId, onClick }: Props) {
   if (isMobile) {
     return (
       <Link
-        href={`/chatbot/${userId}`}
+        href={`/chatbot/${userId}${postId != null ? `?postId=${postId}` : ''}`}
       >
         <Button>
         챗봇 이동
@@ -46,7 +48,7 @@ export function ChatViewButton({ userId, onClick }: Props) {
 
   return (
     <Button onClick={onClick}>
-      이 블로그에 대해 질문하기
+      {variant === 'post' ? '이 글에 대해 질문하기' : '이 블로그에 대해 질문하기'}
     </Button>
   )
 }

--- a/src/components/Chat/ProfileHeader.tsx
+++ b/src/components/Chat/ProfileHeader.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export function ProfileHeader({ profile }: Props) {
   return (
-    <div className="sticky top-0 z-10 w-full max-w-6xl pt-6 pb-4 bg-[rgb(244,246,248)]">
+    <div className="">
       <h1 className="text-3xl font-bold">
         {profile.nickname}의 챗봇
       </h1>

--- a/src/components/Common/Pagination.tsx
+++ b/src/components/Common/Pagination.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React from 'react';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+export interface PaginationProps {
+  page: number; // 0-based
+  totalPages: number;
+  onChange: (page: number) => void;
+  className?: string;
+  showWhenSingle?: boolean; // default: false
+  prevLabel?: string; // default: '이전'
+  nextLabel?: string; // default: '다음'
+  rangeDesktop?: number; // default: 2
+  rangeMobile?: number; // default: 1
+}
+
+function buildPageItems(current: number, total: number, range: number) {
+  const items: (number | 'ellipsis')[] = [];
+  const allThreshold = 2 * range + 5; // first/last + range*2 around current
+  if (!total || total <= allThreshold) {
+    return Array.from({ length: total }, (_, i) => i);
+  }
+
+  const firstIdx = 0;
+  const lastIdx = total - 1;
+  const set = new Set<number>([firstIdx, lastIdx]);
+
+  for (let i = current - range; i <= current + range; i++) {
+    if (i >= firstIdx && i <= lastIdx) set.add(i);
+  }
+
+  if (current <= range) {
+    for (let i = 1; i <= range; i++) set.add(i);
+  }
+  if (current >= lastIdx - range) {
+    for (let i = 1; i <= range; i++) set.add(lastIdx - i);
+  }
+
+  const pages = Array.from(set).sort((a, b) => a - b);
+  for (let i = 0; i < pages.length; i++) {
+    const prev = pages[i - 1];
+    const curr = pages[i];
+    if (i > 0 && curr - prev > 1) items.push('ellipsis');
+    items.push(curr);
+  }
+  return items;
+}
+
+export function Pagination({
+  page,
+  totalPages,
+  onChange,
+  className = '',
+  showWhenSingle = false,
+  prevLabel = '이전',
+  nextLabel = '다음',
+  rangeDesktop = 2,
+  rangeMobile = 1,
+}: PaginationProps) {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const range = isMobile ? rangeMobile : rangeDesktop;
+
+  if (!showWhenSingle && totalPages <= 1) return null;
+
+  const items = buildPageItems(page, totalPages, range);
+  const isFirst = page <= 0;
+  const isLast = page >= totalPages - 1;
+
+  return (
+    <nav className={`py-4 flex justify-center space-x-2 ${className}`} aria-label="Pagination">
+      {!isFirst && (
+        <button
+          type="button"
+          onClick={() => onChange(page - 1)}
+          className="px-3 py-1 border rounded"
+          aria-label="Previous page"
+        >
+          {prevLabel}
+        </button>
+      )}
+
+      {items.map((item, idx) =>
+        item === 'ellipsis' ? (
+          <span key={`e-${idx}`} className="px-3 py-1 text-gray-400 select-none">…</span>
+        ) : (
+          <button
+            key={item}
+            type="button"
+            onClick={() => onChange(item)}
+            aria-current={item === page ? 'page' : undefined}
+            className={`px-3 py-1 border rounded ${
+              item === page ? 'font-bold underline text-blue-600' : ''
+            }`}
+          >
+            {item + 1}
+          </button>
+        )
+      )}
+
+      {!isLast && (
+        <button
+          type="button"
+          onClick={() => onChange(page + 1)}
+          className="px-3 py-1 border rounded"
+          aria-label="Next page"
+        >
+          {nextLabel}
+        </button>
+      )}
+    </nav>
+  );
+}
+
+export default Pagination;
+


### PR DESCRIPTION
feat: 챗봇 게시글 범위 질의(post_id) 지원 + 챗봇 UI 개선

  - aiApi: askChatAPI에 postId 옵션 추가, POST /ai/ask 바디에 post_id 포함
  - SSE: exist_in_post_status 이벤트 파싱해 배지 상태 업데이트
  - PostDetail: ChatViewButton 문구를 “이 글에 대해 질문하기”로, 모바일은 /
  chatbot/:userId?postId=:id 링크
  - ChatWindow: postId(옵션) 지원, 카테고리 필터 숨김, “이 글 범위” 배지에 글 제목 표시,
  배지 행 flex-wrap 적용
  - Chatbot 페이지: ?postId 파싱해 게시글 범위 배지/동작 적용, 카테고리 숨김, 안내 문구
  분기
  - BlogPage: 버튼 문구를 “이 블로그에 대해 질문하기”로 표시(variant=blog)

feat: 페이지 네이션 공용 컴포넌트 도입 + 반응형 축약 페이지 적용

  - src/components/Common/Pagination.tsx 추가 (재사용 가능한 페이지네이션)
  - 데스크탑 ±2 / 모바일 ±1 범위로 숫자 축약, 첫/끝 고정, 중간 … 표시
  - totalPages <= 1이면 nav 미노출, 이전/다음은 유효할 때만 표시
  - HomeClient, BlogPageClient에 컴포넌트 적용하여 중복 제거 및 일관성 확보
  
  
  이전 
  
<img width="1207" height="163" alt="image" src="https://github.com/user-attachments/assets/77de398e-845e-403a-bc9b-4d1c29fdf8fc" />

이후 
<img width="1196" height="129" alt="image" src="https://github.com/user-attachments/assets/7770a551-c8c2-4856-8dbb-dd7504bea497" />
<img width="826" height="489" alt="image" src="https://github.com/user-attachments/assets/7a875744-2240-4769-8a8c-d645db343379" />
<img width="1180" height="483" alt="image" src="https://github.com/user-attachments/assets/324eedda-99b4-4475-ab65-064a7923b081" />


